### PR TITLE
Get more smooth options working:

### DIFF
--- a/lib/mix/tasks/example_test.ex
+++ b/lib/mix/tasks/example_test.ex
@@ -52,28 +52,76 @@ defmodule Mix.Tasks.ExampleTest do
     basic_graphs = [:smooth]
 
     basic_graphs
-    |> Enum.each(
-         fn graph_type ->
-           quick_graph("#{graph_type}", %{type: graph_type})
-           quick_graph("labeled_#{graph_type}", %{type: graph_type, label: "Glucose"})
-         end
-       )
+    |> Enum.each(fn graph_type ->
+      quick_graph("#{graph_type}", %{type: graph_type})
+      quick_graph("labeled_#{graph_type}", %{type: graph_type, label: "Glucose", has_last: true})
+    end)
+
+    quick_graph("smooth_colored", %{type: :smooth, line_color: "purple"})
+
+    quick_graph("smooth_with_target", %{
+      type: :smooth,
+      target: 50,
+      target_color: "#999999",
+      line_color: "#6699cc",
+      underneath_color: "#ebf3f6"
+    })
+
+    quick_graph("smooth_underneath_color", %{
+      type: :smooth,
+      line_color: "#6699cc",
+      underneath_color: "#ebf3f6"
+    })
+
+    [100, 90, 95, 99, 80, 90]
+    |> graph(%{
+      type: :smooth,
+      line_color: "#6699cc",
+      underneath_color: "#ebf3f6"
+    })
+    |> graph_to_file("#{@output_dir}/smooth_similar_nonzero_values.png")
+
+    quick_graph("standard_deviation", %{
+      type: :smooth,
+      height: 100,
+      line_color: "#666",
+      has_std_dev: true,
+      std_dev_color: "#cccccc"
+    })
+
+    quick_graph("standard_deviation_tall", %{
+      type: :smooth,
+      height: 300,
+      line_color: "#666",
+      has_std_dev: true,
+      std_dev_color: "#cccccc"
+    })
+
+    quick_graph("standard_deviation_short", %{
+      type: :smooth,
+      height: 20,
+      line_color: "#666",
+      has_std_dev: true,
+      std_dev_color: "#cccccc"
+    })
 
     write_html()
   end
 
-  def quick_graph(name, options) do
+  defp quick_graph(name, options) do
     @test_data
     |> graph(options)
     |> graph_to_file("#{@output_dir}/#{name}.png")
   end
 
   defp write_html do
-    {:ok, file} = File.open "test/actual/index.html", [:write]
+    {:ok, file} = File.open("test/actual/index.html", [:write])
     IO.binwrite(file, html_header())
     IO.binwrite(file, table_header())
+
     Path.wildcard("test/expected/*")
     |> Enum.each(fn test_file -> IO.binwrite(file, table_row(test_file)) end)
+
     IO.binwrite(file, close())
     File.close(file)
   end
@@ -82,7 +130,9 @@ defmodule Mix.Tasks.ExampleTest do
     """
           <tr>
             <td class="first_column">#{image_tag("../../#{file}")}</td>
-            <td class="last_column">#{image_tag("../../#{String.replace(file, "expected", "actual")}")}</td>
+            <td class="last_column">#{
+      image_tag("../../#{String.replace(file, "expected", "actual")}")
+    }</td>
           </tr>
     """
   end
@@ -132,6 +182,4 @@ defmodule Mix.Tasks.ExampleTest do
       </html>
     """
   end
-
 end
-

--- a/lib/sparklinex.ex
+++ b/lib/sparklinex.ex
@@ -7,6 +7,7 @@ defmodule Sparklinex do
   """
   def graph(data_points, opts = %{type: type}) do
     graph_opts = Map.drop(opts, [:type])
+
     case type do
       :smooth -> smooth(data_points, graph_opts)
     end
@@ -21,7 +22,7 @@ defmodule Sparklinex do
   @doc """
   """
   def graph_to_file(img = %Mogrify.Image{}, path) do
-    {:ok, file} = File.open path, [:write]
+    {:ok, file} = File.open(path, [:write])
     IO.binwrite(file, graph_to_binary(img))
     File.close(file)
   end
@@ -29,9 +30,11 @@ defmodule Sparklinex do
   @doc """
   """
   def graph_to_binary(img = %Mogrify.Image{}) do
-    buffered_image = img
-                     |> Mogrify.custom("stdout", "png:-")
-                     |> Mogrify.create(buffer: true)
+    buffered_image =
+      img
+      |> Mogrify.custom("stdout", "png:-")
+      |> Mogrify.create(buffer: true)
+
     buffered_image.buffer
   end
 end

--- a/lib/sparklinex/chart_data.ex
+++ b/lib/sparklinex/chart_data.ex
@@ -1,5 +1,4 @@
 defmodule Sparklinex.ChartData do
-
   def normalize_data(data, type) do
     min = min_value(data, type)
     max = max_value(data, type)
@@ -13,12 +12,12 @@ defmodule Sparklinex.ChartData do
   defp normalize_data(data, _min, _max, :bullet), do: data
 
   defp normalize_data(data, min, max, _type) do
-    Enum.map(data, &(normalize_value(&1, min, max)))
+    Enum.map(data, &normalize_value(&1, min, max))
   end
 
-  defp normalize_value(_, min, min), do: min
-  defp normalize_value(value, min, max) do
+  def normalize_value(_, min, min), do: min
+
+  def normalize_value(value, min, max) do
     (value - min) / (max - min) * 100
   end
-
 end

--- a/lib/sparklinex/mogrify_draw.ex
+++ b/lib/sparklinex/mogrify_draw.ex
@@ -1,11 +1,11 @@
 defmodule Sparklinex.MogrifyDraw do
   import Mogrify
+
   def create_canvas(width, height, background_color) do
     %Mogrify.Image{path: "test.png", ext: "png"}
     |> custom("size", "#{width}x#{height}")
     |> canvas(background_color)
   end
-
 
   def draw_line(canvas, {{x1, y1}, {x2, y2}}) do
     custom(
@@ -20,18 +20,54 @@ defmodule Sparklinex.MogrifyDraw do
   end
 
   def polygon(canvas, coords, color) do
-    coords_string = coords
-    |> Enum.map(fn {x, y} -> to_string(:io_lib.format("~f, ~f", [x / 1, y / 1])) end)
-    |> Enum.join(" ")
-
     canvas
     |> custom("fill", color)
-    |> custom("polygon", coords_string)
+    |> polygon(coords)
+  end
+
+  def polygon(canvas, coords) do
+    coords_string =
+      coords
+      |> Enum.map(fn {x, y} -> to_string(:io_lib.format("~f, ~f", [x / 1, y / 1])) end)
+      |> Enum.join(" ")
+
+    canvas
+    |> custom("draw", "polygon #{coords_string}")
+  end
+
+  def draw_box(canvas, {x, y}, offset, color) do
+    rectangle(canvas, {x - offset, y - offset}, {x + offset, y + offset}, color)
+  end
+
+  def draw_box(canvas, {x, y}, offset) do
+    rectangle(canvas, {x - offset, y - offset}, {x + offset, y + offset})
+  end
+
+  def rectangle(canvas, {upper_left_x, upper_left_y}, {lower_right_x, lower_right_y}, color) do
+    canvas
+    |> custom("fill", color)
+    |> rectangle({upper_left_x, upper_left_y}, {lower_right_x, lower_right_y})
+  end
+
+  def rectangle(canvas, {upper_left_x, upper_left_y}, {lower_right_x, lower_right_y}) do
+    canvas
+    |> custom(
+      "draw",
+      "rectangle #{
+        to_string(
+          :io_lib.format("~f,~f ~f,~f", [
+            upper_left_x / 1,
+            upper_left_y / 1,
+            lower_right_x / 1,
+            lower_right_y / 1
+          ])
+        )
+      }"
+    )
   end
 
   def set_line_color(canvas, color) do
     canvas
     |> custom("stroke", color)
   end
-
 end

--- a/lib/sparklinex/smooth.ex
+++ b/lib/sparklinex/smooth.ex
@@ -1,25 +1,38 @@
 defmodule Sparklinex.Smooth do
-
   alias Sparklinex.Smooth.Options
   alias Sparklinex.MogrifyDraw
   alias Sparklinex.ChartData
 
   def draw(data, chart_spec = %Options{}) do
     width = width(data, chart_spec)
-    coords = data
-             |> ChartData.normalize_data(:smooth)
-             |> create_coords(chart_spec.height, chart_spec.step)
+    normalized_data = ChartData.normalize_data(data, :smooth)
+
+    coords =
+      normalized_data
+      |> create_coords(chart_spec.height, chart_spec.step)
 
     canvas = MogrifyDraw.create_canvas(width, chart_spec.height, chart_spec.background_color)
 
-    canvas = canvas
+    canvas
+    |> draw_std_dev_box(
+      chart_spec.has_std_dev,
+      normalized_data,
+      chart_spec.height,
+      width,
+      chart_spec.std_dev_color
+    )
     |> MogrifyDraw.set_line_color(chart_spec.line_color)
-
-    if chart_spec.underneath_color do
-      MogrifyDraw.polygon(canvas, poly_coords(coords, chart_spec.height, width), chart_spec.underneath_color)
-    else
-      MogrifyDraw.draw_lines(canvas, each_pair(coords))
-    end
+    |> plot_data(coords, chart_spec.underneath_color, chart_spec.height, width)
+    |> draw_target_line(
+      chart_spec.target,
+      chart_spec.target_color,
+      chart_spec.height,
+      width,
+      data
+    )
+    |> draw_max(chart_spec.has_max, coords, chart_spec.max_color)
+    |> draw_min(chart_spec.has_min, coords, chart_spec.min_color)
+    |> draw_last(chart_spec.has_last, coords, chart_spec.last_color)
   end
 
   defp width(data, %Options{step: step}) do
@@ -29,19 +42,89 @@ defmodule Sparklinex.Smooth do
   defp each_pair([p1 | [p2 | rest]]) do
     [{p1, p2} | each_pair([p2 | rest])]
   end
+
   defp each_pair([_p1 | _rest]), do: []
 
   defp create_coords(data, height, step) do
     data
     |> Enum.with_index()
-    |> Enum.map(fn {y, x} -> {x * step, (height - 3 - y / (101.0 / (height - 4)))} end)
+    |> Enum.map(fn {y, x} -> {x * step, height - 3 - y / (101.0 / (height - 4))} end)
   end
 
   defp poly_coords(coords, height, width) do
     {first_x, first_y} = List.first(coords)
     {last_x, last_y} = List.last(coords)
-    [{-1, height + 1}, {first_x - 1, first_y}, coords, {last_x + 1, last_y}, {width + 1, height + 1}]
+
+    [
+      {-1, height + 1},
+      {first_x - 1, first_y},
+      coords,
+      {last_x + 1, last_y},
+      {width + 1, height + 1}
+    ]
     |> List.flatten()
   end
-end
 
+  defp plot_data(canvas, coords, nil, _height, _width) do
+    MogrifyDraw.draw_lines(canvas, each_pair(coords))
+  end
+
+  defp plot_data(canvas, coords, underneath_color, height, width) do
+    MogrifyDraw.polygon(canvas, poly_coords(coords, height, width), underneath_color)
+  end
+
+  defp draw_std_dev_box(canvas, true, data, height, width, color) do
+    std_dev = Statistics.stdev(data)
+    mid = Enum.sum(data) / length(data)
+    lower = height - 3 - (mid - std_dev) / (101.0 / (height - 4))
+    upper = height - 3 - (mid + std_dev) / (101.0 / (height - 4))
+
+    canvas
+    |> MogrifyDraw.set_line_color("transparent")
+    |> MogrifyDraw.rectangle({0, lower}, {width, upper}, color)
+  end
+
+  defp draw_std_dev_box(canvas, false, _data, _height, _width, _color) do
+    canvas
+  end
+
+  defp draw_target_line(canvas, nil, _target_color, _height, _width, _data) do
+    canvas
+  end
+
+  defp draw_target_line(canvas, target_value, target_color, height, width, data) do
+    norm_value = ChartData.normalize_value(target_value, Enum.min(data), Enum.max(data))
+    adjusted_target_value = height - 3 - norm_value / (101.0 / (height - 4))
+
+    canvas
+    |> MogrifyDraw.set_line_color(target_color)
+    |> MogrifyDraw.draw_line({{-5, adjusted_target_value}, {width + 5, adjusted_target_value}})
+  end
+
+  defp draw_min(canvas, true, coords, color) do
+    min_point = Enum.min_by(coords, fn {_x, y} -> y end)
+    MogrifyDraw.draw_box(canvas, min_point, 2, color)
+  end
+
+  defp draw_min(canvas, false, _coords, _color) do
+    canvas
+  end
+
+  defp draw_max(canvas, true, coords, color) do
+    max_point = Enum.max_by(coords, fn {_x, y} -> y end)
+    MogrifyDraw.draw_box(canvas, max_point, 2, color)
+  end
+
+  defp draw_max(canvas, false, _coords, _color) do
+    canvas
+  end
+
+  defp draw_last(canvas, true, coords, color) do
+    last_point = List.last(coords)
+    MogrifyDraw.draw_box(canvas, last_point, 2, color)
+  end
+
+  defp draw_last(canvas, false, _coords, _color) do
+    canvas
+  end
+end

--- a/lib/sparklinex/smooth/options.ex
+++ b/lib/sparklinex/smooth/options.ex
@@ -1,5 +1,4 @@
 defmodule Sparklinex.Smooth.Options do
-
   defstruct step: 2,
             height: 14,
             background_color: "white",
@@ -15,5 +14,4 @@ defmodule Sparklinex.Smooth.Options do
             target: nil,
             target_color: "white",
             underneath_color: nil
-
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Sparklinex.MixProject do
   def project do
     [
       app: :sparklinex,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       description: description(),
@@ -24,6 +24,7 @@ defmodule Sparklinex.MixProject do
   defp deps do
     [
       {:mogrify, "~> 0.7.0"},
+      {:statistics, "~> 0.5.0"},
       {:credo, "~> 1.0.0", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0.0-rc.4", only: [:dev], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev}
@@ -34,7 +35,9 @@ defmodule Sparklinex.MixProject do
     [
       maintainers: ["Andrew Selder"],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/aselder/sparklinex"}
+      links: %{
+        "GitHub" => "https://github.com/aselder/sparklinex"
+      }
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -9,6 +9,6 @@
   "makeup": {:hex, :makeup, "0.6.0", "e0fd985525e8d42352782bd76253105fbab0a783ac298708ca9020636c9568af", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.11.0", "aa3446f67356afa5801618867587a8863f176f9c632fb62b20f49bd1ea335e8a", [:mix], [{:makeup, "~> 0.6", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "mogrify": {:hex, :mogrify, "0.7.0", "f7af9a42a3b17818c9841dcfa12f7416c4c34078872eb79b2dc55e15670c3a7f", [:mix], [], "hexpm"},
-  "mogrify_draw": {:hex, :mogrify_draw, "0.1.1", "858e0eb209bad3d408cfce4845e49e049395f2ae80c0802ecf0b0b8c1b954207", [:mix], [{:mogrify, "~> 0.5.4", [hex: :mogrify, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "statistics": {:hex, :statistics, "0.5.1", "963c1d3a56d504a5559b469614203bcd366aac94e08515b61b3b239638ee8873", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
- standard deviation box
- target value
- fix underneath color
- min, max, last markers

This implements all the options that the RubyGem has except for
`label`.

Label will be difficult to implement due to the inability to get type
metrics using Mogrify.